### PR TITLE
Add action to add all issues to the project board

### DIFF
--- a/.github/workflows/project_action.yaml
+++ b/.github/workflows/project_action.yaml
@@ -1,0 +1,40 @@
+name: Add issues to T5 Development Project Board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_URL: https://github.com/orgs/lbl-cbg/projects/1
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PEM: ${{ secrets.APP_PEM }}
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: tibdex/github-app-token@v1.7.0
+        with:
+          app_id: ${{ env.APP_ID }}
+          private_key: ${{ env.APP_PEM }}
+
+      - name: Add issue to Developer Board
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ steps.generate_token.outputs.token }}
+        continue-on-error: false
+
+      - name: Debug Info
+        if: failure()
+        run: |
+          echo "Failed to add issue to project board"
+          echo "Event: ${{ toJson(github.event) }}"
+          echo "Token: ${{ steps.generate_token.outputs.token }}"


### PR DESCRIPTION
Here a GitHub action to automatically add all issues to our project board.

Before merging this PR we need to complete the following set up steps 

1. **Create a GitHub App:**
   - Go to your GitHub account settings.
   - Navigate to `Developer settings` -> `GitHub Apps`.
   - Click on `New GitHub App`.
   - Fill in the required fields and set the necessary permissions:
     - **Repository permissions:** Issues (Read & Write)
     - **Organization permissions:** Projects (Read & Write)
   - Click `Create GitHub App`.
   - Generate a private key and download the `.pem` file.

2. **Store GitHub App ID and Private Key as Secrets:**
   - Go to your repository on GitHub.
   - Navigate to `Settings` -> `Secrets and variables` -> `Actions secrets`.
   - Add a new secret for the App ID (`APP_ID`).
   - Add another secret for the private key (`APP_PEM`), pasting the content of the `.pem` file.

3. **Install the GitHub App on Your Organization:**
   - Go to the GitHub App settings page.
   - Click on `Install App` in the left sidebar.
   - Select your organization from the list.
   - Choose the repositories you want the app to have access to.
   - Complete the installation.

4. **Merge and test the workflow**
   - Merge the PR and create a test issue to make sure the workflow correctly adds the issue the board

    
